### PR TITLE
Fixed duration selection

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -15,7 +15,7 @@ function selectTimeValueByElementId(elementId) {
     document.getElementById('duration-input').value = '';
     var selected = document.getElementById(elementId);
     removeSelected();
-    setDurationInfoText(timeValue);
+    //setDurationInfoText(timeValue);
     selected.className += " selected";
 };
 


### PR DESCRIPTION
Method call setDurationInfoText(timeValue) in function selectTimeValueByElementId(elementId) tries to set InnerHTLM value to a currently non-existing element. Because of this, the selected -class is not applied to the duration selection. Removing the method call fixed this.